### PR TITLE
feat: add autocomplete prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ export default BasicExample;
     <td>'[ ,;]'</td>
     <td></td>
   </tr>
+   <tr>
+    <td>
+    autoComplete</td>
+    <td>string | undefined</td>
+    <td></td>
+    <td></td>
+  </tr>
 </table>
 
 ## License

--- a/react-multi-email/ReactMultiEmail.tsx
+++ b/react-multi-email/ReactMultiEmail.tsx
@@ -28,6 +28,7 @@ export interface IReactMultiEmailProps {
   spinner?: () => React.ReactNode;
   delimiter?: string;
   initialInputValue?: string;
+  autoComplete?: string;
 }
 
 export function ReactMultiEmail(props: IReactMultiEmailProps) {
@@ -51,7 +52,8 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
     spinner,
     delimiter = '[ ,;]',
     initialInputValue = '',
-    inputClassName
+    inputClassName,
+    autoComplete,
   } = props;
   const emailInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -163,7 +165,7 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
     async (value: string) => {
       await findEmailAddress(value);
     },
-    [findEmailAddress, onChangeInput],
+    [findEmailAddress],
   );
 
   const removeEmail = React.useCallback(
@@ -265,6 +267,7 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
         onKeyUp={handleOnKeyup}
         autoFocus={autoFocus}
         className={inputClassName}
+        autoComplete={autoComplete}
       />
     </div>
   );


### PR DESCRIPTION
In this Pull Request, 

Problem: 

I can't manage the `input` element `autoComplete` prop.

Solution: 
Add `autoComplete` prop to `ReactMultiEmail` with type.

The Way of Development:

- I added to `autoComplete` prop to `ReactMultiEmail` to handle the `input` element `autoComplete` prop. I thought that it help us to get this point.

- Update Read.me file to keep props up to date.

- Remove unused `onChangeInput` dependency from useEffect, line: 166

Note: If you think this development is a chore and there is something that I can't be aware of or a way that I can handle my problem, please close this pull request and let me know the way. :)