### PR TITLE
Fix logic about props 'emails'

### DIFF
--- a/react-multi-email/ReactMultiEmail.tsx
+++ b/react-multi-email/ReactMultiEmail.tsx
@@ -35,11 +35,16 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
   const {
     id,
     style,
-    getLabel,
+    emails: propsEmails,
     className = '',
     noClass,
     placeholder,
     autoFocus,
+    delimiter = '[ ,;]',
+    initialInputValue = '',
+    inputClassName,
+    autoComplete,
+    getLabel,
     enable,
     onDisabled,
     validateEmail,
@@ -50,22 +55,18 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
     onKeyDown,
     onKeyUp,
     spinner,
-    delimiter = '[ ,;]',
-    initialInputValue = '',
-    inputClassName,
-    autoComplete,
   } = props;
   const emailInputRef = React.useRef<HTMLInputElement>(null);
 
   const [focused, setFocused] = React.useState(false);
-  const [emails, setEmails] = React.useState<string[]>([]);
+  const [emails, setEmails] = React.useState<string[]>(propsEmails ?? []);
   const [inputValue, setInputValue] = React.useState(initialInputValue);
   const [spinning, setSpinning] = React.useState(false);
 
   const findEmailAddress = React.useCallback(
     async (value: string, isEnter?: boolean) => {
       const validEmails: string[] = [];
-      let inputValue: string = '';
+      let inputValue = '';
       const re = new RegExp(delimiter, 'g');
       const isEmail = validateEmail || isEmailFn;
 
@@ -234,10 +235,6 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
     setFocused(true);
     onFocus?.();
   }, [onFocus]);
-
-  React.useEffect(() => {
-    setEmails(props.emails ?? []);
-  }, [props.emails]);
 
   return (
     <div

--- a/react-multi-email/ReactMultiEmail.tsx
+++ b/react-multi-email/ReactMultiEmail.tsx
@@ -31,6 +31,13 @@ export interface IReactMultiEmailProps {
   autoComplete?: string;
 }
 
+const initialEmailAddress = (emails?: string[]) => {
+  if (typeof emails === 'undefined') return [];
+
+  const validEmails = emails.filter(email => isEmail(email));
+  return validEmails;
+};
+
 export function ReactMultiEmail(props: IReactMultiEmailProps) {
   const {
     id,
@@ -62,13 +69,6 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
   const [emails, setEmails] = React.useState<string[]>(() => initialEmailAddress(propsEmails));
   const [inputValue, setInputValue] = React.useState(initialInputValue);
   const [spinning, setSpinning] = React.useState(false);
-
-  const initialEmailAddress = (emails?: string[]) => {
-    if (typeof emails === 'undefined') return [];
-
-    const validEmails = emails.filter(email => isEmail(email));
-    return validEmails;
-  };
 
   const findEmailAddress = React.useCallback(
     async (value: string, isEnter?: boolean) => {

--- a/react-multi-email/ReactMultiEmail.tsx
+++ b/react-multi-email/ReactMultiEmail.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isEmail as isEmailFn } from './isEmail';
+import { isEmail, isEmail as isEmailFn } from './isEmail';
 
 export interface IReactMultiEmailProps {
   id?: string;
@@ -59,9 +59,16 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
   const emailInputRef = React.useRef<HTMLInputElement>(null);
 
   const [focused, setFocused] = React.useState(false);
-  const [emails, setEmails] = React.useState<string[]>(propsEmails ?? []);
+  const [emails, setEmails] = React.useState<string[]>(() => initialEmailAddress(propsEmails));
   const [inputValue, setInputValue] = React.useState(initialInputValue);
   const [spinning, setSpinning] = React.useState(false);
+
+  const initialEmailAddress = (emails?: string[]) => {
+    if (typeof emails === 'undefined') return [];
+
+    const validEmails = emails.filter(email => isEmail(email));
+    return validEmails;
+  };
 
   const findEmailAddress = React.useCallback(
     async (value: string, isEnter?: boolean) => {


### PR DESCRIPTION
## props로 들어가는 `emails`에 대한 로직 변경 의견

@thomasJang 해당 로직으로 돌려도 돌아갈 것 같은데 검증 부탁드리겠습니다.!


결국 내부 emails state에 props로 들어오는 `emails`가 세팅이 되어야해서 해당 `useEffect` 구문이 있는것 같은데
그렇다면 초기 useState값에 세팅이 되어도 기존 로직과 동일하게 동작하지 않을까 싶어서 의견 드립니다

+ 추가로 props로 들어오는 email에 대해서도 validation check가 필요할 것 같아서 initialEmailAddress를 추가했습니다. 