### PR TITLE
fix(reactmultiemail.tsx): trim emails with space after comma

### DIFF
--- a/react-multi-email/ReactMultiEmail.tsx
+++ b/react-multi-email/ReactMultiEmail.tsx
@@ -106,7 +106,7 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
 
             if (typeof validateResult === 'boolean') {
               if (validateResult) {
-                addEmails('' + arr.shift());
+                addEmails('' + arr.shift()?.trim());
               } else {
                 if (allowDisplayName) {
                   const validateResultWithDisplayName = isEmail('' + arr[0].trim(), { allowDisplayName });


### PR DESCRIPTION
trim emails with space after comma. If you copy something like: email1@domain.com, email2@domain.com, email3@domain.com the space is