### PR TITLE
Handle case insensitive duplicate emails

### DIFF
--- a/react-multi-email/ReactMultiEmail.tsx
+++ b/react-multi-email/ReactMultiEmail.tsx
@@ -88,7 +88,7 @@ export function ReactMultiEmail(props: IReactMultiEmailProps) {
       const addEmails = (email: string) => {
         if (!allowDuplicate) {
           for (let i = 0, l = emails.length; i < l; i++) {
-            if (emails[i] === email) {
+            if (emails[i].toLowerCase() === email.toLowerCase()) {
               return false;
             }
           }

--- a/test/allowDuplicate.test.tsx
+++ b/test/allowDuplicate.test.tsx
@@ -62,3 +62,20 @@ it('allowDuplicate = undefined', async () => {
   const emailsWrapper = document.querySelector('.data-labels');
   expect(emailsWrapper?.childElementCount)?.toBe(1);
 });
+
+it('allowDuplicate = false, case sensitive', async () => {
+  const { getByRole } = render(createReactMultiEmail(false));
+  const textbox = getByRole('textbox');
+
+  const num = 3;
+  for (let i = 0; i < num; i++) {
+    fireEvent.change(textbox, { target: { value: `test@example.com` } });
+    fireEvent.keyUp(textbox, { key: 'Enter', code: 'Enter' });
+  }
+
+  fireEvent.change(textbox, { target: { value: `Test@example.com` } });
+  fireEvent.keyUp(textbox, { key: 'Enter', code: 'Enter' });
+
+  const emailsWrapper = document.querySelector('.data-labels');
+  expect(emailsWrapper?.childElementCount)?.toBe(1);
+});


### PR DESCRIPTION
## Duplicate checks are error prone

Either with malicious intent or unknowingly, a user can enter same email multiple times when not checks for case sensitivity.

This PR adds `toLowerCase()` check when adding new email so duplicate checks are robust.